### PR TITLE
[SELC-3419] feat: allow notifications for prod-io with FAST pricingPlan to be sent to SAP

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/InstitutionToSend.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/InstitutionToSend.java
@@ -23,6 +23,7 @@ public class InstitutionToSend {
     private String county;
     private String subUnitCode;
     private String subUnitType;
+//    private String category; //fixme: for now this field doesn't have to be sent to outer products
     private RootParent rootParent;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/NotificationToSend.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/NotificationToSend.java
@@ -17,6 +17,7 @@ public class NotificationToSend {
     private OffsetDateTime closedAt;
     private OffsetDateTime updatedAt;
     private NotificationType type;
+    private String pricingPlan;
     private InstitutionToSend institution;
     private String fileName;
     private String contentType;

--- a/connector/kafka-manager/src/main/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotification.java
+++ b/connector/kafka-manager/src/main/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotification.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.commons.base.utils.Origin;
+import it.pagopa.selfcare.commons.base.utils.PricingPlan;
+import it.pagopa.selfcare.commons.base.utils.ProductId;
 import it.pagopa.selfcare.external_interceptor.connector.api.ExternalApiConnector;
 import it.pagopa.selfcare.external_interceptor.connector.api.KafkaSapSendService;
 import it.pagopa.selfcare.external_interceptor.connector.api.RegistryProxyConnector;
@@ -79,7 +81,11 @@ public class SendSapNotification extends KafkaSend implements KafkaSapSendServic
                 && isOriginAllowed(notification, allowedOrigins);
     }
     private boolean isProductAllowed(Notification notification, Optional<List<String>> allowedProducts) {
-        return allowedProducts.isPresent() && allowedProducts.get().contains(notification.getProduct());
+        return (allowedProducts.isPresent() && allowedProducts.get().contains(notification.getProduct())) || isProdIoFast(notification.getProduct(), notification.getPricingPlan());
+    }
+
+    private boolean isProdIoFast(String productId, String pricingPlan){
+        return ProductId.PROD_IO.getValue().equals(productId) && PricingPlan.FA.name().equals(pricingPlan);
     }
 
     private boolean isInstitutionTypeAllowed(Notification notification, Optional<Set<InstitutionType>> allowedTypes) {

--- a/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendFdNotificationTest.java
+++ b/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendFdNotificationTest.java
@@ -169,7 +169,7 @@ class SendFdNotificationTest {
         verify(kafkaTemplate, times(1)).send(eq(allowedTopics.get("prod-fd")), userCaptor.capture());
         verify(acknowledgment, times(1)).acknowledge();
         NotificationToSend captured = mapper.readValue(userCaptor.getValue(), NotificationToSend.class);
-        checkNotNullFields(captured, "institution", "billing", "state", "closedAt", "fileName", "contentType");
+        checkNotNullFields(captured, "institution", "billing", "state", "closedAt", "fileName", "contentType", "pricingPlan");
     }
 
     @Test
@@ -301,7 +301,7 @@ class SendFdNotificationTest {
         verify(kafkaTemplate, times(2)).send(eq(allowedTopics.get("prod-fd")), userCaptor.capture());
         verify(acknowledgment, times(1)).acknowledge();
         NotificationToSend captured = mapper.readValue(userCaptor.getValue(), NotificationToSend.class);
-        checkNotNullFields(captured, "institution", "billing", "state", "closedAt", "fileName", "contentType");
+        checkNotNullFields(captured, "institution", "billing", "state", "closedAt", "fileName", "contentType", "pricingPlan");
     }
 
     @Test

--- a/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotificationTest.java
+++ b/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotificationTest.java
@@ -113,12 +113,12 @@ class SendSapNotificationTest {
     @Test
     void sendInstitutionNotificationEc() throws JsonProcessingException {
         //given
-        final Notification notification = mockInstance(new Notification());
+        final Notification notification = createNotificationMock();
         Institution institution = mockInstance(new Institution(), "setCity");
         institution.setSubUnitType("EC");
         institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
-        final Billing billing = mockInstance(new Billing());
+        final Billing billing = createBillingMock();
         notification.setInstitution(institution);
         notification.setBilling(billing);
         notification.setProduct("prod-io-premium");
@@ -158,12 +158,12 @@ class SendSapNotificationTest {
     @Test
     void sendInstitutionNotificationUo() throws JsonProcessingException {
         //given
-        final Notification notification = mockInstance(new Notification());
+        final Notification notification = createNotificationMock();
         Institution institution = mockInstance(new Institution(), "setCity");
         institution.setSubUnitType("UO");
         institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
-        final Billing billing = mockInstance(new Billing());
+        final Billing billing = createBillingMock();
         notification.setInstitution(institution);
         notification.setBilling(billing);
         notification.setProduct("prod-pn");
@@ -203,12 +203,12 @@ class SendSapNotificationTest {
     @Test
     void sendInstitutionNotificationAoo() throws JsonProcessingException {
         //given
-        final Notification notification = mockInstance(new Notification());
+        final Notification notification = createNotificationMock();
         Institution institution = mockInstance(new Institution(), "setCity");
         institution.setSubUnitType("AOO");
         institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
-        final Billing billing = mockInstance(new Billing());
+        final Billing billing = createBillingMock();
         notification.setInstitution(institution);
         notification.setBilling(billing);
         notification.setProduct("prod-pn");
@@ -248,12 +248,12 @@ class SendSapNotificationTest {
     @Test
     void sendInstitutionNotification_NotFound() throws JsonProcessingException {
         //given
-        final Notification notification = mockInstance(new Notification());
+        final Notification notification = createNotificationMock();
         Institution institution = mockInstance(new Institution(), "setCity");
         institution.setSubUnitType("AOO");
         institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
-        final Billing billing = mockInstance(new Billing());
+        final Billing billing = createBillingMock();
         notification.setInstitution(institution);
         notification.setBilling(billing);
         notification.setProduct("prod-pn");
@@ -285,12 +285,12 @@ class SendSapNotificationTest {
     @Test
     void sendSapNotification_nullSubUnitType() throws JsonProcessingException {
         //given
-        final Notification notification = mockInstance(new Notification());
-        Institution institution = mockInstance(new Institution());
+        final Notification notification = createNotificationMock();
+        Institution institution = createInstitutionMock();
         institution.setSubUnitType(null);
         institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
-        final Billing billing = mockInstance(new Billing());
+        final Billing billing = createBillingMock();
         notification.setInstitution(institution);
         notification.setBilling(billing);
         notification.setProduct("prod-pn");
@@ -321,10 +321,10 @@ class SendSapNotificationTest {
     void noExcludedInstitutionTypes() {
         //given
         service = new SendSapNotification(kafkaTemplate, notificationMapperSpy, mapper, registryProxyConnector, externalApiConnector, null, List.of("prod-pn"), Set.of(Origin.IPA));
-        final Notification notification = mockInstance(new Notification());
-        final Institution institution = mockInstance(new Institution());
-        final OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
-        final Billing billing = mockInstance(new Billing());
+        final Notification notification = createNotificationMock();
+        final Institution institution = createInstitutionMock();
+        final OnboardedProduct onboardedProduct = createOnboardedProductMock();
+        final Billing billing = createBillingMock();
         onboardedProduct.setBilling(billing);
         institution.setOnboarding(List.of(onboardedProduct));
         notification.setProduct("prod-pn");
@@ -342,10 +342,10 @@ class SendSapNotificationTest {
     void allowedProductsNotPresent() {
         //given
         service = new SendSapNotification(kafkaTemplate, notificationMapperSpy, mapper, registryProxyConnector, externalApiConnector, Set.of(InstitutionType.PA), null, Set.of(Origin.IPA));
-        final Notification notification = mockInstance(new Notification());
-        final Institution institution = mockInstance(new Institution());
-        final OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
-        final Billing billing = mockInstance(new Billing());
+        final Notification notification = createNotificationMock();
+        final Institution institution = createInstitutionMock();
+        final OnboardedProduct onboardedProduct = createOnboardedProductMock();
+        final Billing billing = createBillingMock();
         onboardedProduct.setBilling(billing);
         institution.setOnboarding(List.of(onboardedProduct));
         institution.setInstitutionType(InstitutionType.PA);
@@ -363,11 +363,11 @@ class SendSapNotificationTest {
     void notificationInstitutionType_notPresent() {
         //given
         service = new SendSapNotification(kafkaTemplate, notificationMapperSpy, mapper, registryProxyConnector, externalApiConnector, Set.of(InstitutionType.PA), List.of("prod-pn"), Set.of(Origin.IPA));
-        final Notification notification = mockInstance(new Notification());
-        final Institution institution = mockInstance(new Institution());
+        final Notification notification = createNotificationMock();
+        final Institution institution = createInstitutionMock();
         institution.setInstitutionType(InstitutionType.SA);
-        final OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
-        final Billing billing = mockInstance(new Billing());
+        final OnboardedProduct onboardedProduct = createOnboardedProductMock();
+        final Billing billing = createBillingMock();
         onboardedProduct.setBilling(billing);
         institution.setOnboarding(List.of(onboardedProduct));
         notification.setInstitution(institution);
@@ -384,11 +384,11 @@ class SendSapNotificationTest {
     void productNotAllowed() {
         //given
         service = new SendSapNotification(kafkaTemplate, notificationMapperSpy, mapper, registryProxyConnector, externalApiConnector, Set.of(InstitutionType.PA), List.of("prod-pn"), Set.of(Origin.IPA));
-        final Notification notification = mockInstance(new Notification());
-        final Institution institution = mockInstance(new Institution());
+        final Notification notification = createNotificationMock();
+        final Institution institution = createInstitutionMock();
         institution.setInstitutionType(InstitutionType.SA);
-        final OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
-        final Billing billing = mockInstance(new Billing());
+        final OnboardedProduct onboardedProduct = createOnboardedProductMock();
+        final Billing billing = createBillingMock();
         onboardedProduct.setBilling(billing);
         institution.setOnboarding(List.of(onboardedProduct));
         notification.setInstitution(institution);
@@ -401,6 +401,26 @@ class SendSapNotificationTest {
         verifyNoInteractions(kafkaTemplate);
     }
 
+    @Test
+    void isProdIoFast(){
+        //given
+        final Notification notification = createNotificationMock();
+        notification.setPricingPlan("FA");
+        final Institution institution = createInstitutionMock();
+        institution.setInstitutionType(InstitutionType.SA);
+        final OnboardedProduct onboardedProduct = createOnboardedProductMock();
+        final Billing billing = createBillingMock();
+        onboardedProduct.setBilling(billing);
+        institution.setOnboarding(List.of(onboardedProduct));
+        notification.setInstitution(institution);
+        notification.setState("ACTIVE");
+        notification.setProduct("prod-io");
+        //when
+        Executable executable = () -> service.sendInstitutionNotification(notification, acknowledgment);
+        //then
+        assertDoesNotThrow(executable);
+        verifyNoInteractions(kafkaTemplate);
+    }
     @Test
     void allowedOriginsNotPresent() {
         //given
@@ -448,12 +468,12 @@ class SendSapNotificationTest {
     @Test
     void sendOldEvents() throws JsonProcessingException {
         //given
-        final Notification notification = mockInstance(new Notification());
-        final Institution institution = mockInstance(new Institution());
+        final Notification notification = createNotificationMock();
+        final Institution institution = createInstitutionMock();
         institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
-        final OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
-        final Billing billing = mockInstance(new Billing());
+        final OnboardedProduct onboardedProduct = createOnboardedProductMock();
+        final Billing billing = createBillingMock();
         onboardedProduct.setBilling(billing);
         institution.setOnboarding(List.of(onboardedProduct));
         notification.setInstitution(institution);
@@ -478,6 +498,22 @@ class SendSapNotificationTest {
         NotificationToSend captured = mapper.readValue(institutionCaptor.getValue(), NotificationToSend.class);
         checkNotNullFields(captured, "user");
         checkNotNullFields(captured.getInstitution(), "subUnitType");
+    }
 
+
+    private static Notification createNotificationMock(){
+        return mockInstance(new Notification());
+    }
+
+    private static Institution createInstitutionMock(){
+        return mockInstance(new Institution());
+    }
+
+    private static Billing createBillingMock(){
+        return mockInstance(new Billing());
+    }
+
+    private static OnboardedProduct createOnboardedProductMock(){
+        return mockInstance(new OnboardedProduct());
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

allow notifications for prod-io with FAST pricingPlan to be sent to SAP

#### Motivation and Context

Prod-io onboarding with FAST pricingPlan is a billable product, hence it has to be sent to sap too

#### How Has This Been Tested?

tested locally by running the application and doing an onbaording from front end for prod-io fast
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.