### PR TITLE
[SELC-3460] feat: added tag external-v2 for automatic generation of open-api

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -29,7 +29,7 @@
   "paths" : {
     "/interceptor/acknowledgment/{productId}/message/{messageId}/status/{status}" : {
       "post" : {
-        "tags" : [ "interceptor" ],
+        "tags" : [ "external-v2" ],
         "summary" : "messageAcknowledgment",
         "description" : "Service to acknowledge message consumption by a consumer",
         "operationId" : "messageAcknowledgmentUsingPOST",

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -29,7 +29,7 @@
   "paths" : {
     "/interceptor/acknowledgment/{productId}/message/{messageId}/status/{status}" : {
       "post" : {
-        "tags" : [ "external-v2" ],
+        "tags" : [ "external-v2", "interceptor" ],
         "summary" : "messageAcknowledgment",
         "description" : "Service to acknowledge message consumption by a consumer",
         "operationId" : "messageAcknowledgmentUsingPOST",

--- a/web/src/main/java/it/pagopa/selfcare/external_interceptor/web/controller/InterceptorController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_interceptor/web/controller/InterceptorController.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.external_interceptor.web.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.external_interceptor.connector.model.interceptor.AckStatus;
 import it.pagopa.selfcare.external_interceptor.core.InterceptorService;
@@ -27,6 +28,7 @@ public class InterceptorController {
         this.interceptorService = interceptorService;
     }
 
+    @Tag(name = "external-v2")
     @ApiOperation(value = "", notes = "${swagger.external-interceptor.acknowledgment.api.messageAcknowledgment}")
     @ResponseStatus(HttpStatus.OK)
     @PostMapping(value = "/acknowledgment/{productId}/message/{messageId}/status/{status}")

--- a/web/src/main/java/it/pagopa/selfcare/external_interceptor/web/controller/InterceptorController.java
+++ b/web/src/main/java/it/pagopa/selfcare/external_interceptor/web/controller/InterceptorController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.external_interceptor.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.external_interceptor.connector.model.interceptor.AckStatus;
 import it.pagopa.selfcare.external_interceptor.core.InterceptorService;
@@ -28,7 +29,7 @@ public class InterceptorController {
         this.interceptorService = interceptorService;
     }
 
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "interceptor")})
     @ApiOperation(value = "", notes = "${swagger.external-interceptor.acknowledgment.api.messageAcknowledgment}")
     @ResponseStatus(HttpStatus.OK)
     @PostMapping(value = "/acknowledgment/{productId}/message/{messageId}/status/{status}")


### PR DESCRIPTION
#### List of Changes

Added new tag external-v2 for operation that will be include into open-api for APIM

#### Motivation and Context

In order to avoid manual construction of open-api for APIM, all operations that will be included into this document are tagged with external-v2 or support. In this way, a step of github action will scan them and automatically include into open-api.