### PR TITLE
SELC-4785 feat: added control to use the invoicing tax code for UOs that have it

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/Billing.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/Billing.java
@@ -6,6 +6,6 @@ import lombok.Data;
 public class Billing {
     private String vatNumber;
     private String recipientCode;
+    private String taxCodeInvoicing;
     private boolean publicService;
-
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/Institution.java
@@ -15,7 +15,6 @@ public class Institution {
     private String address;
     private String zipCode;
     private String taxCode;
-    private String taxCodeInvoicing;
     private String origin;
     private Billing billing;
     private InstitutionType institutionType;

--- a/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/external_interceptor/connector/model/institution/Institution.java
@@ -15,6 +15,7 @@ public class Institution {
     private String address;
     private String zipCode;
     private String taxCode;
+    private String taxCodeInvoicing;
     private String origin;
     private Billing billing;
     private InstitutionType institutionType;

--- a/connector/kafka-manager/src/main/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotification.java
+++ b/connector/kafka-manager/src/main/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotification.java
@@ -66,8 +66,8 @@ public class SendSapNotification extends KafkaSend implements KafkaSapSendServic
         if (checkAllowedNotification(notification)) {
             log.debug(LogUtils.CONFIDENTIAL_MARKER, "send institution notification = {}", notification);
             NotificationToSend notificationToSend = notificationMapper.createInstitutionNotification(notification);
-            if (StringUtils.hasText(notification.getInstitution().getTaxCodeInvoicing())) {
-                notificationToSend.getInstitution().setTaxCode(notification.getInstitution().getTaxCodeInvoicing());
+            if (notification.getBilling() != null && StringUtils.hasText(notification.getBilling().getTaxCodeInvoicing())) {
+                notificationToSend.getInstitution().setTaxCode(notification.getBilling().getTaxCodeInvoicing());
             }
             setNotificationInstitutionLocationFields(notificationToSend);
             setNotificationToSendInstitutionDescription(notificationToSend);

--- a/connector/kafka-manager/src/main/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotification.java
+++ b/connector/kafka-manager/src/main/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotification.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -65,6 +66,9 @@ public class SendSapNotification extends KafkaSend implements KafkaSapSendServic
         if (checkAllowedNotification(notification)) {
             log.debug(LogUtils.CONFIDENTIAL_MARKER, "send institution notification = {}", notification);
             NotificationToSend notificationToSend = notificationMapper.createInstitutionNotification(notification);
+            if (StringUtils.hasText(notification.getInstitution().getTaxCodeInvoicing())) {
+                notificationToSend.getInstitution().setTaxCode(notification.getInstitution().getTaxCodeInvoicing());
+            }
             setNotificationInstitutionLocationFields(notificationToSend);
             setNotificationToSendInstitutionDescription(notificationToSend);
             notificationToSend.setType(NotificationType.ADD_INSTITUTE);
@@ -77,23 +81,24 @@ public class SendSapNotification extends KafkaSend implements KafkaSapSendServic
     }
 
     private static void setNotificationToSendInstitutionDescription(NotificationToSend notificationToSend) {
-        if(notificationToSend.getInstitution().getRootParent() != null) {
+        if (notificationToSend.getInstitution().getRootParent() != null) {
             notificationToSend.getInstitution().setDescription(
                     notificationToSend.getInstitution().getRootParent().getDescription()
                             + " - " + notificationToSend.getInstitution().getDescription());
         }
     }
 
-    private boolean checkAllowedNotification(Notification notification){
+    private boolean checkAllowedNotification(Notification notification) {
         return isProductAllowed(notification, allowedProducts)
                 && isInstitutionTypeAllowed(notification, allowedInstitutionTypes)
                 && isOriginAllowed(notification, allowedOrigins);
     }
+
     private boolean isProductAllowed(Notification notification, Optional<List<String>> allowedProducts) {
         return (allowedProducts.isPresent() && allowedProducts.get().contains(notification.getProduct())) || isProdIoFast(notification.getProduct(), notification.getPricingPlan());
     }
 
-    private boolean isProdIoFast(String productId, String pricingPlan){
+    private boolean isProdIoFast(String productId, String pricingPlan) {
         return ProductId.PROD_IO.getValue().equals(productId) && PricingPlan.FA.name().equals(pricingPlan);
     }
 

--- a/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotificationTest.java
+++ b/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotificationTest.java
@@ -119,9 +119,9 @@ class SendSapNotificationTest {
         Institution institution = mockInstance(new Institution(), "setCity", "setRootParent");
         institution.setSubUnitType("EC");
         institution.setOrigin("IPA");
-        institution.setTaxCodeInvoicing(null);
         institution.setInstitutionType(InstitutionType.PA);
         final Billing billing = createBillingMock();
+        billing.setTaxCodeInvoicing(null);
         notification.setInstitution(institution);
         notification.setBilling(billing);
         notification.setProduct("prod-io-premium");
@@ -159,13 +159,12 @@ class SendSapNotificationTest {
     }
 
     @Test
-    void sendInstitutionNotificationEcWithTaxCodeInvoicing() throws JsonProcessingException {
+    void sendInstitutionNotificationUOWithTaxCodeInvoicing() throws JsonProcessingException {
         //given
         final Notification notification = createNotificationMock();
         Institution institution = mockInstance(new Institution(), "setCity", "setRootParent");
         institution.setSubUnitType("UO");
         institution.setOrigin("IPA");
-        institution.setTaxCodeInvoicing("taxCodeInvoicing");
         institution.setInstitutionType(InstitutionType.PA);
         final Billing billing = createBillingMock();
         notification.setInstitution(institution);
@@ -202,6 +201,7 @@ class SendSapNotificationTest {
         NotificationToSend captured = mapper.readValue(producerRecordArgumentCaptor.getValue().value(), NotificationToSend.class);
         checkNotNullFields(captured, "user");
         checkNotNullFields(captured.getInstitution(), "rootParent");
+        assertEquals("setTaxCodeInvoicing", captured.getInstitution().getTaxCode());
 
     }
 

--- a/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotificationTest.java
+++ b/connector/kafka-manager/src/test/java/it/pagopa/selfcare/external_interceptor/connector/kafka_manager/factory/SendSapNotificationTest.java
@@ -119,6 +119,7 @@ class SendSapNotificationTest {
         Institution institution = mockInstance(new Institution(), "setCity", "setRootParent");
         institution.setSubUnitType("EC");
         institution.setOrigin("IPA");
+        institution.setTaxCodeInvoicing(null);
         institution.setInstitutionType(InstitutionType.PA);
         final Billing billing = createBillingMock();
         notification.setInstitution(institution);
@@ -155,6 +156,53 @@ class SendSapNotificationTest {
         NotificationToSend captured = mapper.readValue(producerRecordArgumentCaptor.getValue().value(), NotificationToSend.class);
         checkNotNullFields(captured, "user");
         checkNotNullFields(captured.getInstitution(), "rootParent");
+    }
+
+    @Test
+    void sendInstitutionNotificationEcWithTaxCodeInvoicing() throws JsonProcessingException {
+        //given
+        final Notification notification = createNotificationMock();
+        Institution institution = mockInstance(new Institution(), "setCity", "setRootParent");
+        institution.setSubUnitType("UO");
+        institution.setOrigin("IPA");
+        institution.setTaxCodeInvoicing("taxCodeInvoicing");
+        institution.setInstitutionType(InstitutionType.PA);
+        final Billing billing = createBillingMock();
+        notification.setInstitution(institution);
+        notification.setBilling(billing);
+        notification.setProduct("prod-io-premium");
+        notification.setState("ACTIVE");
+        OrganizationUnit organizationUnit = mockInstance(new OrganizationUnit());
+        GeographicTaxonomies proxyTaxonomy = mockInstance(new GeographicTaxonomies());
+        proxyTaxonomy.setCountry("proxyContry");
+        proxyTaxonomy.setProvinceAbbreviation("proxyProvince");
+        proxyTaxonomy.setDescription("proxyCity - COMUNE");
+        proxyTaxonomy.setIstatCode(organizationUnit.getMunicipalIstatCode());
+        when(registryProxyConnector.getUoById(any())).thenReturn(organizationUnit);
+        when(registryProxyConnector.getExtById(any())).thenReturn(proxyTaxonomy);
+        when(kafkaTemplate.send(any(ProducerRecord.class)))
+                .thenReturn(mockFuture);
+
+        doAnswer(invocationOnMock -> {
+            ListenableFutureCallback callback = invocationOnMock.getArgument(0);
+            callback.onSuccess(mockSendResult);
+            return null;
+        }).when(mockFuture).addCallback(any(ListenableFutureCallback.class));
+
+        //when
+        Executable executable = () -> service.sendInstitutionNotification(notification, acknowledgment);
+        //then
+        assertDoesNotThrow(executable);
+        ArgumentCaptor<ProducerRecord<String, String>> producerRecordArgumentCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
+        verify(kafkaTemplate, times(1)).send(producerRecordArgumentCaptor.capture());
+        verify(acknowledgment, times(1)).acknowledge();
+        verify(registryProxyConnector, times(1)).getUoById(notification.getInstitution().getSubUnitCode());
+        verify(registryProxyConnector, times(1)).getExtById(organizationUnit.getMunicipalIstatCode());
+        verifyNoMoreInteractions(registryProxyConnector);
+        NotificationToSend captured = mapper.readValue(producerRecordArgumentCaptor.getValue().value(), NotificationToSend.class);
+        checkNotNullFields(captured, "user");
+        checkNotNullFields(captured.getInstitution(), "rootParent");
+
     }
 
     @Test
@@ -244,7 +292,7 @@ class SendSapNotificationTest {
         verifyNoMoreInteractions(registryProxyConnector);
         NotificationToSend captured = mapper.readValue(producerRecordArgumentCaptor.getValue().value(), NotificationToSend.class);
         checkNotNullFields(captured, "user");
-        assertEquals("Sc-Contracts-Sap",producerRecordArgumentCaptor.getValue().topic());
+        assertEquals("Sc-Contracts-Sap", producerRecordArgumentCaptor.getValue().topic());
         checkNotNullFields(captured.getInstitution());
     }
 
@@ -276,7 +324,8 @@ class SendSapNotificationTest {
         //then
         assertDoesNotThrow(executable);
         ArgumentCaptor<ProducerRecord<String, String>> producerRecordArgumentCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
-        verify(kafkaTemplate, times(1)).send(producerRecordArgumentCaptor.capture());;
+        verify(kafkaTemplate, times(1)).send(producerRecordArgumentCaptor.capture());
+        ;
         verify(acknowledgment, times(1)).acknowledge();
         verify(registryProxyConnector, times(1)).getAooById(institution.getSubUnitCode());
         verifyNoMoreInteractions(registryProxyConnector);
@@ -404,7 +453,7 @@ class SendSapNotificationTest {
     }
 
     @Test
-    void isProdIoFast(){
+    void isProdIoFast() {
         //given
         final Notification notification = createNotificationMock();
         notification.setPricingPlan("FA");
@@ -423,6 +472,7 @@ class SendSapNotificationTest {
         assertDoesNotThrow(executable);
         verifyNoInteractions(kafkaTemplate);
     }
+
     @Test
     void allowedOriginsNotPresent() {
         //given
@@ -446,7 +496,7 @@ class SendSapNotificationTest {
     }
 
     @Test
-    void originNotAllowed(){
+    void originNotAllowed() {
         //given
         service = new SendSapNotification(kafkaTemplate, notificationMapperSpy, mapper, registryProxyConnector, externalApiConnector, Set.of(InstitutionType.PA, InstitutionType.GSP), List.of("prod-pn"), Set.of(Origin.IPA));
         final Notification notification = new Notification();
@@ -503,19 +553,19 @@ class SendSapNotificationTest {
     }
 
 
-    private static Notification createNotificationMock(){
+    private static Notification createNotificationMock() {
         return mockInstance(new Notification());
     }
 
-    private static Institution createInstitutionMock(){
+    private static Institution createInstitutionMock() {
         return mockInstance(new Institution());
     }
 
-    private static Billing createBillingMock(){
+    private static Billing createBillingMock() {
         return mockInstance(new Billing());
     }
 
-    private static OnboardedProduct createOnboardedProductMock(){
+    private static OnboardedProduct createOnboardedProductMock() {
         return mockInstance(new OnboardedProduct());
     }
 }


### PR DESCRIPTION
#### List of Changes

Added control to use the invoicing tax code for UOs that have it

#### Motivation and Context

UOs that have the invoicing tax code must use it as the tax code for products that consume the SAP queue

#### How Has This Been Tested?


#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.